### PR TITLE
(#24) add new citests to enforce git commit conventions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,54 @@ name: Compile Check
 on:
   pull_request:
     branches: 
-      - 'release/jerrieee' # Only run on PRs targeting this branch
+      - 'release/**' # Only run on PRs targeting this branch
   push:
     branches: 
-      - 'release/jerrieee' # Only run on pushes to this branch
+      - 'release/**' # Only run on pushes to this branch
   workflow_dispatch:
 
 jobs:
+  check-commit-messages:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages for issue number
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Checking commits from $BASE_SHA to $HEAD_SHA"
+          COMMITS=$(git log $BASE_SHA..$HEAD_SHA --format="%H %s")
+          FAILED=0
+
+          while IFS= read -r line; do
+            SHA=$(echo "$line" | cut -d' ' -f1)
+            MESSAGE=$(echo "$line" | cut -d' ' -f2-)
+
+            # Matches: #123, PROJ-123, [#123], (#123), etc.
+            if echo "$MESSAGE" | grep -qE '(#[0-9]+|[A-Z]+-[0-9]+)'; then
+              echo "✅ $SHA: \"$MESSAGE\""
+            else
+              echo "❌ $SHA: \"$MESSAGE\" — missing issue number (e.g. #123 or PROJ-123)"
+              FAILED=1
+            fi
+          done <<< "$COMMITS"
+
+          if [ $FAILED -ne 0 ]; then
+            echo ""
+            echo "One or more commits are missing an issue number."
+            echo "Each commit message must reference an issue, e.g.:"
+            echo "  Fix null pointer dereference #42"
+            echo "  feat: add retry logic PROJ-101"
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
 
@@ -28,3 +69,29 @@ jobs:
 
       - name: Build Project
         run: make
+
+  check-single-commit:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for single commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          COMMIT_COUNT=$(git rev-list $BASE_SHA..$HEAD_SHA --count)
+          echo "Commits in PR: $COMMIT_COUNT"
+
+          if [ "$COMMIT_COUNT" -ne 1 ]; then
+            echo "❌ PRs must contain exactly 1 commit. Found $COMMIT_COUNT commits."
+            echo "Please squash your commits before merging."
+            exit 1
+          fi
+
+          echo "✅ Exactly 1 commit found."


### PR DESCRIPTION
- checks if there's one commit in PR (requires one to squash commits before merging)
- checks if issue is mentioned in commit history.